### PR TITLE
Kinesis connector dependencies for all Flink versions

### DIFF
--- a/src/main/java/com/amazonaws/kda/flinkchecker/FlinkKinesisVersionCheck.java
+++ b/src/main/java/com/amazonaws/kda/flinkchecker/FlinkKinesisVersionCheck.java
@@ -2,19 +2,24 @@ package com.amazonaws.kda.flinkchecker;
 
 import org.apache.maven.model.Dependency;
 
+import java.util.Optional;
+
 /**
  * Ensures that the version of the Kinesis connector `flink-connector-kinesis` includes critical fixes
- * required for production readiness.
+ * required for production readiness.<br/>
+ * <br/>
  * For Flink 1.15: flink-connector-kinesis `1.15.4` is recommended. A warning is issued if this is not the case.
- * flink-connector-kinesis `1.15.4` includes a fix for a critical bug where Flink Kinesis EFO Consumer can fail to stop gracefully (FLINK-31183)
- * Other Flink versions are not yet covered.
+ * flink-connector-kinesis `1.15.4` includes a fix for a critical bug where Flink Kinesis EFO Consumer can fail to stop
+ * gracefully (FLINK-31183)<br/>
+ * <br/>
+ * See {@link FlinkVersionDependencies} for the recommended Kinesis connectors matrix for all Flink versions
  */
 public class FlinkKinesisVersionCheck extends Check {
 
 	@Override
 	public CheckResult check(CheckParams params) {
 		Dependency flinkDep = params.dependencies.stream().filter(dep -> dep.getGroupId().equals("org.apache.flink") &&
-				dep.getArtifactId().equals("flink-streaming-java")).findAny().orElse(null);
+				dep.getArtifactId().startsWith("flink-streaming-java")).findAny().orElse(null);
 
 		CheckResult result = new CheckResult().checkName("Kinesis Connector Version Check").success(true);
 		if (flinkDep == null) {
@@ -24,42 +29,43 @@ public class FlinkKinesisVersionCheck extends Check {
 
 		String flinkVersion = flinkDep.getVersion();
 
-		Dependency kinesisDep = params.dependencies.stream().filter(dep -> dep.getGroupId().equals("org.apache.flink") &&
-				dep.getArtifactId().equals("flink-connector-kinesis")).findAny().orElse(null);
+		Optional<FlinkVersionDependencies> flinkVersionDeps = FlinkVersionDependencies.from(flinkVersion);
+
+		if (!flinkVersionDeps.isPresent()) {
+			return result;
+		}
+
+		Dependency requiredDep = flinkVersionDeps.get().getDependency();
+
+		Dependency kinesisDep = params.dependencies.stream()
+				.filter(dep -> {
+					String artifactId = dep.getArtifactId();
+					return artifactId.startsWith(FlinkVersionDependencies.KINESIS_CONNECTOR_ARTIFACT_ID)
+							|| artifactId.startsWith(FlinkVersionDependencies.KINESIS_EFO_CONNECTOR_ARTIFACT_ID);
+				})
+				.findAny()
+				.orElse(null);
 
 		if (kinesisDep == null) {
 			params.log.debug("No Flink kinesis connector dependency found");
 			return result;
 		}
 
-		if (flinkVersion.startsWith("1.15")) {
-			String requiredKinesisConnectorVersion = "1.15.4";
-			if (kinesisDep.getVersion().equals(requiredKinesisConnectorVersion)) {
-				params.log.info("✅ Flink Kinesis connector version check passed.");
-				return result;
-			}
-
-			params.log.warn(String.format("❌ For Flink %s, the recommended version for org.apache.flink:flink-connector-kinesis is %s or later",
-					flinkVersion, requiredKinesisConnectorVersion));
+		String requiredVersion = requiredDep.getVersion();
+		if (!kinesisDep.getGroupId().equals(requiredDep.getGroupId())
+				|| !kinesisDep.getArtifactId().equals(requiredDep.getArtifactId())) {
+			params.log.warn(String.format("❌ For Flink %s, the recommended Kinesis connector dependency is %s:%s:%s",
+					flinkVersion, requiredDep.getGroupId(), requiredDep.getArtifactId(), requiredVersion));
 			return result.success(false);
 		}
 
-		if (flinkVersion.startsWith("1.13")) {
-			return result;
+		if (!kinesisDep.getVersion().equals(requiredVersion)) {
+			params.log.warn(String.format("❌ For Flink %s, the recommended version for %s:%s is %s or later",
+					flinkVersion, requiredDep.getGroupId(), requiredDep.getArtifactId(), requiredVersion));
+			return result.success(false);
 		}
 
-		if (flinkVersion.startsWith("1.11")) {
-			return result;
-		}
-
-		if (flinkVersion.startsWith("1.8")) {
-			return result;
-		}
-
-		if (flinkVersion.startsWith("1.6")) {
-			return result;
-		}
-
+		params.log.info("✅ Flink Kinesis connector version check passed.");
 		return result;
 	}
 }

--- a/src/main/java/com/amazonaws/kda/flinkchecker/FlinkVersionDependencies.java
+++ b/src/main/java/com/amazonaws/kda/flinkchecker/FlinkVersionDependencies.java
@@ -1,0 +1,93 @@
+package com.amazonaws.kda.flinkchecker;
+
+import org.apache.maven.model.Dependency;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+/**
+ * <pre>
+ * | Flink version | Recommended Kinesis connector                                 |
+ * | ------------- | ------------------------------------------------------------- |
+ * | 1.15          | org.apache.flink:flink-connector-kinesis:1.15.4               |
+ * | 1.13          | org.apache.flink:flink-connector-kinesis_2.12:1.13.6          |
+ * | 1.11          | software.amazon.kinesis:amazon-kinesis-connector-flink:2.4.1  |
+ * | 1.8           | software.amazon.kinesis:amazon-kinesis-connector-flink:1.6.1  |
+ * | 1.6           | org.apache.flink:flink-connector-kinesis_2.11:1.6.4           |
+ * </pre>
+ */
+public enum FlinkVersionDependencies {
+	FLINK_1_15("1.15") {
+		@Override
+		public String getKinesisVersion() { return "1.15.4"; }
+	},
+	FLINK_1_13("1.13") {
+		@Override
+		public String getScalaVersion() { return "2.12"; }
+		@Override
+		public String getKinesisVersion() { return "1.13.6"; }
+	},
+	FLINK_1_11("1.11") {
+		@Override
+		public String getGroupId() { return KINESIS_EFO_CONNECTOR_GROUP_ID; };
+		@Override
+		public String getArtifactId() { return KINESIS_EFO_CONNECTOR_ARTIFACT_ID; };
+		@Override
+		public String getKinesisVersion() { return "2.4.1"; }
+	},
+	FLINK_1_8("1.8") {
+		@Override
+		public String getGroupId() { return KINESIS_EFO_CONNECTOR_GROUP_ID; };
+		@Override
+		public String getArtifactId() { return KINESIS_EFO_CONNECTOR_ARTIFACT_ID; };
+		@Override
+		public String getKinesisVersion() { return "1.6.1"; }
+	},
+	FLINK_1_6("1.6") {
+		@Override
+		public String getScalaVersion() { return "2.11"; }
+		@Override
+		public String getKinesisVersion() { return "1.6.4"; }
+	};
+
+	private static String KINESIS_CONNECTOR_GROUP_ID = "org.apache.flink";
+	public static String KINESIS_CONNECTOR_ARTIFACT_ID = "flink-connector-kinesis";
+
+	private static String KINESIS_EFO_CONNECTOR_GROUP_ID = "software.amazon.kinesis";
+	public static String KINESIS_EFO_CONNECTOR_ARTIFACT_ID = "amazon-kinesis-connector-flink";
+
+	private String version;
+
+	public String getGroupId() {
+		return KINESIS_CONNECTOR_GROUP_ID;
+	};
+
+	public String getScalaVersion() {
+		return null;
+	};
+
+	public String getArtifactId() {
+		String scalaVersion = getScalaVersion();
+		return scalaVersion == null
+				? KINESIS_CONNECTOR_ARTIFACT_ID : KINESIS_CONNECTOR_ARTIFACT_ID + "_" + scalaVersion;
+	};
+
+	abstract public String getKinesisVersion();
+
+	public Dependency getDependency() {
+		Dependency dep = new Dependency();
+		dep.setGroupId(getGroupId());
+		dep.setArtifactId(getArtifactId());
+		dep.setVersion(getKinesisVersion());
+		return dep;
+	}
+
+	FlinkVersionDependencies(String version) {
+		this.version = version;
+	}
+
+	public static Optional<FlinkVersionDependencies> from(String version) {
+		return Arrays.stream(FlinkVersionDependencies.values())
+				.filter(versionDeps -> version.startsWith(versionDeps.version)).findAny();
+	}
+}


### PR DESCRIPTION
*Recommended Kinesis connectors matrix for all Flink versions*

| Flink version | Recommended Kinesis connector                                 |
| ------------- | ------------------------------------------------------------- |
| 1.15          | org.apache.flink:flink-connector-kinesis:1.15.4               |
| 1.13          | org.apache.flink:flink-connector-kinesis_2.12:1.13.6          |
| 1.11          | software.amazon.kinesis:amazon-kinesis-connector-flink:2.4.1  |
| 1.8           | software.amazon.kinesis:amazon-kinesis-connector-flink:1.6.1  |
| 1.6           | org.apache.flink:flink-connector-kinesis_2.11:1.6.4           |


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
